### PR TITLE
Bug Fixes: Empty Beers/Cheers & Executing a command mid-statement

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,0 +1,38 @@
+import { was } from "..";
+import { Message, TextChannel, Guild, Client } from "discord.js";
+import { App } from "../app";
+
+describe("Discord Bot Message Listener", () => {
+  let testMessage: Message;
+  let testClient: Client;
+  let guild: Guild;
+  let app: App;
+
+  testClient = new Client();
+  // @ts-ignore
+  app = new App(testClient, {});
+  guild = new Guild(testClient, {
+    emojis: []
+  });
+  testMessage = new Message(
+    new TextChannel(guild, {}),
+    {
+      author: {
+        id: "authorId"
+      },
+      embeds: [],
+      attachments: []
+    },
+    new Client()
+  );
+
+  it("should return true if the first word in the message is !beers", () => {
+    testMessage.content = "!beers two hearted ale";
+    expect(was(testMessage, "!beers")).toBeTruthy();
+  });
+
+  it("should return false if it finds a command in the middle of a string", () => {
+    testMessage.content = "what happens if I type !beers in the middle?";
+    expect(was(testMessage, "!beers")).toBeFalsy();
+  });
+});

--- a/src/app.ts
+++ b/src/app.ts
@@ -27,9 +27,15 @@ export class App {
 
   public cheersHandler(message: Discord.Message) {
     let drinkName = message.content.replace("!cheers", "").trimLeft();
-    addDrink(this.pgClient, message, drinkName);
 
-    message.channel.send("Enjoy that brewchacho, brochacho. 🍺");
+    if (drinkName.length === 0) {
+      message.channel.send(
+        "You can't cheers with an empty glass! Add the name of what you're drinking after you !cheers"
+      );
+    } else {
+      addDrink(this.pgClient, message, drinkName);
+      message.channel.send("Enjoy that brewchacho, brochacho. 🍺");
+    }
   }
 
   public async drinkCountHandler(message: Discord.Message) {
@@ -77,6 +83,12 @@ export class App {
 
   public async beerHandler(message: Discord.Message) {
     let drinkName = message.content.replace("!beers", "").trimLeft();
+    if (drinkName.length === 0) {
+      message.channel.send(
+        "You can't raise a beer without providing a name! Make sure to include the name of the beer you're drinking after !beers"
+      );
+      return;
+    }
     await addDrink(this.pgClient, message, drinkName);
     try {
       const data = await getBeerInformation(drinkName);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,10 @@ app.client.on("message", (msg: Discord.Message) => {
   }
 });
 
-function was(msg: Discord.Message, command: string) {
-  return msg.content.toLowerCase().includes(command);
+export function was(msg: Discord.Message, command: string) {
+  // Only look for a command at the beginning of a message
+  return msg.content
+    .split(" ")[0]
+    .toLowerCase()
+    .includes(command);
 }

--- a/src/network.ts
+++ b/src/network.ts
@@ -19,7 +19,6 @@ const initializeDatabase = (client: Client) => {
 };
 
 const addDrink = (client: Client, message: Message, drinkName: string) => {
-  console.log(drinkName);
   client.query(
     `
             INSERT INTO drinks (username, guild, drinkname, active) 


### PR DESCRIPTION
Prevents the user from entering an empty `!beers` or `!cheers`. Just shows an error message.

Previously, you could do something like `show me a !beers what would happen` and the system would add a beer with `what would happen`, which is lame. Also this could get you into some kind of an infinite loop. You can no longer do this :). 